### PR TITLE
Update serde-derive past precompiled binaries removal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,9 +854,9 @@ checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,13 @@ tracing = { version = "0.1.37", default-features = false, features = ["attribute
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["env-filter", "fmt", "ansi", "tracing-log"] }
 ureq = { version = "2.6.2", default-features = false, features = ["gzip", "brotli", "tls", "http-interop"] }
 
+[target.'cfg(any())'.dependencies]
 # enforce working minimal-versions
-proc-macro2 = { version = "1.0.60", optional = true, default-features = false }
+proc-macro2 = { version = "1.0.60", default-features = false }
 
 # avoid precompiled binaries https://github.com/serde-rs/serde/issues/2538
-serde_derive = { version = "1.0, <1.0.172", default-features = false }
+serde_derive = { version = "1.0.185", default-features = false }
 
-[build-dependencies]
+[target.'cfg(any())'.build-dependencies]
 # enforce working minimal-versions
-pkg-config = { version = "0.3.27", optional = true, default-features = false }
+pkg-config = { version = "0.3.27", default-features = false }


### PR DESCRIPTION
Also use a better formulation for applying version restrictions. See https://github.com/matklad/macro-dep-test for details.